### PR TITLE
Adds support for inline script and style tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,17 @@ The basic index.html file built by ember-cli will look soemething like this:
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/dummy-app.css">
+    <style>
+      body { background: red; }
+    </style>
   </head>
 
   <body>
     <script src="assets/vendor.js"></script>
     <script src="assets/dummy-app.js"></script>
+    <script>
+        GlobalThing.API_KEY = '123';
+    </script>
   </body>
 </html>
 ```
@@ -121,10 +127,20 @@ This index.html is used to boot the ember app by retrieving the relevant js and 
     },
     {
       "src": "assets/dummy-app.js"
+    },
+    {
+      "content": "GlobalThing.API_KEY = '123';"
+    }
+  ],
+  "style": [
+    {
+      "content": "body { background: red; }"
     }
   ]
 }
 ```
+
+Note that if the `script` tag uses `src` property, it is included as a path, whereas if the `script` tag has javascript content, it is set as the `content` property of the script item. All stylesheet links are included in the `link` property of the output, while inline styles are added to the `style` property.
 
 ## Why would I use this plugin?
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,12 @@ module.exports = {
           },
           script: {
             selector: 'script',
-            attributes: ['src']
+            attributes: ['src'],
+            allowContent: true
+          },
+          style: {
+            selector: 'style',
+            allowContent: true
           }
         }
       },

--- a/lib/utilities/extract-index-config.js
+++ b/lib/utilities/extract-index-config.js
@@ -1,19 +1,28 @@
 var cheerio   = require('cheerio');
 var RSVP      = require('rsvp');
 
-function _get($, selector, attributes) {
+function _get($, selector, attributes, allowContent) {
   attributes = attributes || [];
   var config = [];
   var $tags = $(selector);
 
   $tags.each(function() {
     var $tag = $(this);
+    var data = {};
 
-    var data = attributes.reduce(function(data, attribute) {
-      data[attribute] = $tag.attr(attribute);
+    if (attributes.length) {
+      data = attributes.reduce(function(data, attribute) {
+        data[attribute] = $tag.attr(attribute);
 
-      return data;
-    }, {});
+        if(data[attribute] === undefined && allowContent) {
+          data['content'] = $tag.text().trim();
+        }
+
+        return data;
+      }, data);
+    } else if (allowContent) {
+      data['content'] = $tag.text().trim();
+    }
 
     config.push(data);
   });
@@ -26,11 +35,11 @@ module.exports = function(data) {
   var blueprint = this.readConfig('jsonBlueprint');
   var json = {};
 
-  for(var prop in blueprint) {
+  for (var prop in blueprint) {
     var value = blueprint[prop];
 
-    if (value.selector && value.attributes) {
-      json[prop] = _get($, value.selector, value.attributes);
+    if (value.selector) {
+      json[prop] = _get($, value.selector, value.attributes, value.allowContent);
     }
   }
 

--- a/tests/fixtures/dist/index.html
+++ b/tests/fixtures/dist/index.html
@@ -12,11 +12,22 @@
 
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/app.css">
-
+    <style>
+body {
+  background-color: red;
+  color: blue;
+}
+    </style>
   </head>
   <body>
     <script src="assets/vendor.js"></script>
     <script src="assets/app.js"></script>
+    <script>
+// Do some javascript
+console.log("Hello, world");
+var things = ['a', 'b', 'c'];
+things.sort();
+    </script>
   </body>
 </html>
 

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -65,7 +65,7 @@ describe('the deploy plugin object', function() {
         .then(function() {
           var json = require(fakeRoot + '/dist/index.json');
 
-          assert.equal(Object.keys(json).length, 4);
+          assert.equal(Object.keys(json).length, 5);
 
           assert.deepEqual(json.base[0], { href: '/' });
           assert.deepEqual(json.meta[0], { name: 'my-app/config/environment', content: 'some-config-values' });
@@ -73,10 +73,12 @@ describe('the deploy plugin object', function() {
           assert.deepEqual(json.link[1], { rel: 'stylesheet', href: 'assets/app.css' });
           assert.deepEqual(json.script[0], { src: 'assets/vendor.js' });
           assert.deepEqual(json.script[1], { src: 'assets/app.js' });
+          assert.deepEqual(json.script[2], { content: '// Do some javascript\nconsole.log("Hello, world");\nvar things = [\'a\', \'b\', \'c\'];\nthings.sort();' });
+          assert.deepEqual(json.style[0], { content: 'body {\n  background-color: red;\n  color: blue;\n}' });
         });
     });
 
-    it ('returns the index.json path', function() {
+    it('returns the index.json path', function() {
       return assert.isFulfilled(promise)
         .then(function(result) {
           assert.deepEqual(result.distFiles, ['index.json']);
@@ -93,7 +95,7 @@ describe('the deploy plugin object', function() {
           .then(function() {
             var json = require(fakeRoot + '/dist/index.json');
 
-            assert.equal(Object.keys(json).length, 4);
+            assert.equal(Object.keys(json).length, 5);
           });
       });
     });


### PR DESCRIPTION
* Adds `allowContent` to json blueprint for script and style tags
* Update tests to test for inline content

Not sure if this is useful (or safe?!), but I wanted to play around with an ember-cli-deploy plugin a bit, so here we are.

This change adds the ability to add inline scripts and styles to json-config. In certain apps we are using [ember-cli-inline-content](https://github.com/gdub22/ember-cli-inline-content), which allows "inlining" javascript configurations in a script tag, .e.g.:

```
<script>
   GlobalToConfig.API_KEY = 'abc123';
</script>
```

With the current iteration, these end up as empty nodes in the json-config output. This change adds support for this and inline styles as well. 

Happy to clean it up or fix security holes. Tests provided, but may be improved.