### PR TITLE
Fix case distDir is an absolute path

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ module.exports = {
         var fileOutputPattern  = this.readConfig('fileOutputPattern');
         var inputPath          = path.join(distDir, fileInputPattern);
         var outputPath         = path.join(distDir, fileOutputPattern);
-        var absoluteInputPath  = path.join(root, inputPath);
-        var absoluteOutputPath = path.join(root, outputPath);
+        var absoluteInputPath  = path.resolve(root, inputPath);
+        var absoluteOutputPath = path.resolve(root, outputPath);
 
         this.log('generating `' + outputPath + '` from `' + inputPath + '`', { verbose: true });
 

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* globals require, describe, before, beforeEach, it, process */
+
 var fs     = require('fs');
 var path   = require('path');
 var assert = require('ember-cli/tests/helpers/assert');
@@ -8,9 +10,11 @@ describe('the deploy plugin object', function() {
   var fakeRoot;
   var plugin;
   var promise;
+  var distDir;
 
   before(function() {
-    fakeRoot =  process.cwd() + '/tests/fixtures';
+    fakeRoot = process.cwd() + '/tests/fixtures';
+    distDir = 'dist';
   });
 
   beforeEach(function() {
@@ -33,7 +37,7 @@ describe('the deploy plugin object', function() {
           fileInputPattern: 'index.html',
           fileOutputPattern: 'index.json',
           distDir: function(context) {
-            return 'dist';
+            return distDir;
           },
           projectRoot: function(context) {
             return fakeRoot;
@@ -79,6 +83,23 @@ describe('the deploy plugin object', function() {
         .then(function(result) {
           assert.deepEqual(result.distFiles, ['index.json']);
         });
+    });
+
+    describe('when the distDir is an absolute path', function() {
+      before(function() {
+        distDir = fakeRoot + '/dist';
+      });
+
+      it('still works', function() {
+        return assert.isFulfilled(promise)
+          .then(function() {
+            var json = require(fakeRoot + '/dist/index.json');
+
+            assert.equal(Object.keys(json).length, 4);
+          });
+      });
+
+
     });
   });
 });

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* globals require, describe, before, beforeEach, it, process */
-
 var fs     = require('fs');
 var path   = require('path');
 var assert = require('ember-cli/tests/helpers/assert');
@@ -98,8 +96,6 @@ describe('the deploy plugin object', function() {
             assert.equal(Object.keys(json).length, 4);
           });
       });
-
-
     });
   });
 });


### PR DESCRIPTION
Before, if `distDir` was an absolute path, `absoluteInputPath` would end up having rootPath doubled.  This uses `path.resolve` instead of `path.join` to resolve that issue.