### PR TITLE
Added jsonBlueprintOverride option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,49 @@ The root directory where the file matching `fileInputPattern` will be searched f
 
 *Default:* `context.distDir`
 
+### jsonBlueprint
+
+The tags, attributes, and values to extract from the output file and into JSON
+
+*Default:* ```javascript
+  {
+    base: {
+      selector: 'base',
+      attributes: ['href']
+    },
+    meta: {
+      selector: 'meta[name*="/config/environment"]',
+      attributes: ['name', 'content']
+    },
+    link: {
+      selector: 'link',
+      attributes: ['rel', 'href', 'integrity']
+    },
+    script: {
+      selector: 'script',
+      attributes: ['src', 'integrity']
+    }
+  }
+```
+
+### jsonBlueprintOverride
+
+If you wish to override just one portion of the jsonBlueprint and leave the rest intact changes made here will
+be merged into jsonBlueprint.
+
+*Default:* `{}`
+
+*Example:*
+```javascript
+  {
+    script: {
+      selector: 'script',
+      attributes: ['src']
+    }
+  }
+```
+Would no longer extract the integrity attribue from script tags to be included.
+
 ## What does a converted index.html file look like?
 
 The basic index.html file built by ember-cli will look soemething like this:

--- a/index.js
+++ b/index.js
@@ -52,9 +52,9 @@ module.exports = {
 
       configure: function(context){
         this._super.configure.call(this, context);
-        let override = this.readConfig('jsonBlueprintOverride');
-        let blueprint = this.readConfig('jsonBlueprint');
-        for (let key in override) { blueprint[key] = override[key]; }
+        var override = this.readConfig('jsonBlueprintOverride');
+        var blueprint = this.readConfig('jsonBlueprint');
+        for (var key in override) { blueprint[key] = override[key]; }
 
         this.combinedBlueprint = blueprint;
       },

--- a/index.js
+++ b/index.js
@@ -46,7 +46,17 @@ module.exports = {
             selector: 'script',
             attributes: ['src', 'integrity']
           }
-        }
+        },
+        jsonBlueprintOverride: {},
+      },
+
+      configure: function(context){
+        this._super.configure.call(this, context);
+        let override = this.readConfig('jsonBlueprintOverride');
+        let blueprint = this.readConfig('jsonBlueprint');
+        for (let key in override) { blueprint[key] = override[key]; }
+
+        this.combinedBlueprint = blueprint;
       },
 
       didBuild: function(context) {

--- a/lib/utilities/extract-index-config.js
+++ b/lib/utilities/extract-index-config.js
@@ -23,7 +23,7 @@ function _get($, selector, attributes) {
 
 module.exports = function(data) {
   var $ = cheerio.load(data.toString());
-  var blueprint = this.readConfig('jsonBlueprint');
+  var blueprint = this.combinedBlueprint;
   var json = {};
 
   for(var prop in blueprint) {

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -9,10 +9,14 @@ describe('the deploy plugin object', function() {
   var plugin;
   var promise;
   var distDir;
+  var jsonBlueprint;
+  var jsonBlueprintOverride;
 
   before(function() {
     fakeRoot = process.cwd() + '/tests/fixtures';
     distDir = 'dist';
+    jsonBlueprint = null;
+    jsonBlueprintOverride = null;
   });
 
   beforeEach(function() {
@@ -43,6 +47,13 @@ describe('the deploy plugin object', function() {
         }
       }
     };
+
+    if (jsonBlueprint) {
+      context.config['json-config'].jsonBlueprint = jsonBlueprint;
+    }
+    if (jsonBlueprintOverride) {
+      context.config['json-config'].jsonBlueprintOverride = jsonBlueprintOverride;
+    }
 
     plugin.beforeHook(context);
     plugin.configure(context);
@@ -95,6 +106,90 @@ describe('the deploy plugin object', function() {
 
             assert.equal(Object.keys(json).length, 4);
           });
+      });
+    });
+  });
+
+  describe('configure hook', function() {
+    it('combinedBlueprint echos the default config when there are no options set', function() {
+      assert.deepEqual(plugin.defaultConfig.jsonBlueprint, plugin.combinedBlueprint);
+    });
+    describe('sending jsonBlueprint', function() {
+      var newBlueprint = {
+        script: {
+          'foo': 'bar'
+        }
+      };
+      before(function() {
+        jsonBlueprint = newBlueprint;
+        jsonBlueprintOverride = null;
+      });
+
+      it('changes combinedBlueprint', function() {
+        assert.deepEqual(newBlueprint, plugin.combinedBlueprint);
+      });
+    });
+    describe('send jsonBlueprintOverride', function() {
+
+      var newScript = {
+        'now': 'different'
+      };
+      before(function() {
+        jsonBlueprint = null;
+        jsonBlueprintOverride = {
+          script: newScript
+        };
+      });
+
+      it('modifies combinedBlueprint', function() {
+        var original = JSON.parse(JSON.stringify(plugin.defaultConfig.jsonBlueprint));
+        original.script = newScript;
+        assert.deepEqual(original, plugin.combinedBlueprint);
+      });
+    });
+    describe('send jsonBlueprintOverride with a new key', function() {
+
+      var newBody = {
+        'class': 'different'
+      };
+      before(function() {
+        jsonBlueprint = null;
+        jsonBlueprintOverride = {
+          body: newBody
+        };
+      });
+
+      it('appends to combinedBlueprint', function() {
+        var original = JSON.parse(JSON.stringify(plugin.defaultConfig.jsonBlueprint));
+        original.body = newBody;
+        assert.deepEqual(original, plugin.combinedBlueprint);
+      });
+    });
+    describe('send both jsonBlueprint and jsonBlueprintOverride', function() {
+      var newScript = {
+        'foo': 'bar'
+      };
+      var newBlueprint = {
+        meta: {
+          selector: 'meta[name*="/config/environment"]',
+          attributes: ['name', 'content']
+        },
+        script: {
+          selector: 'script',
+          attributes: ['src', 'integrity']
+        }
+      };
+      before(function() {
+        jsonBlueprint = newBlueprint;
+        jsonBlueprintOverride = {
+          script: newScript
+        }
+      });
+
+      it('still works', function() {
+        var blueprint = JSON.parse(JSON.stringify(newBlueprint));
+        blueprint.script = newScript;
+        assert.deepEqual(blueprint, plugin.combinedBlueprint);
       });
     });
   });

--- a/tests/unit/lib/utilities/extract-index-config-nodetest.js
+++ b/tests/unit/lib/utilities/extract-index-config-nodetest.js
@@ -15,17 +15,15 @@ describe('extract-index-config', function() {
     var contents = fs.readFileSync(process.cwd() + '/tests/fixtures/dist/index.html');
 
     var plugin = {
-      readConfig: function(key) {
-        return {
-          base: {
-            selector: 'base',
-            attributes: ['href']
-          },
-          script: {
-            selector: 'script',
-            attributes: ['src']
-          }
-        };
+      combinedBlueprint: {
+        base: {
+          selector: 'base',
+          attributes: ['href']
+        },
+        script: {
+          selector: 'script',
+          attributes: ['src']
+        }
       }
     };
 


### PR DESCRIPTION
## What Changed & Why

During the configuration hook `jsonBlueprintOverride` is merged with `jsonBlueprint` to allow
individual sections to be modified or new sections added.
## Related issues

Makes #22 possible 
Fixes #20 
## PR Checklist
- [x] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]
## People

@achambers

Is this the correct approach?
Better name for this option than _jsonBlueprintOverride_?
