### PR TITLE
Support Inline scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,45 @@ The root directory where the file matching `fileInputPattern` will be searched f
 
 *Default:* `context.distDir`
 
+### jsonBlueprint
+
+The blueprint indicating what fields to read from the HTML file and convert into JSON.
+
+*Default:*
+```javascript
+base: {
+  selector: 'base',
+  attributes: ['href']
+},
+meta: {
+  selector: 'meta[name*="/config/environment"]',
+  attributes: ['name', 'content']
+},
+link: {
+  selector: 'link',
+  attributes: ['rel', 'href', 'integrity']
+},
+script: {
+  selector: 'script',
+  attributes: ['src', 'integrity'],
+  includeContent: false,
+}
+```
+
+### includeContent
+By default only the attributes of `<script>` tags are read and included in the
+JSON output.  If you wish to include the content of the script tag you must specify that.
+```javascript
+ENV['json-config'] = {
+  jsonBlueprint(context, pluginHelper) {
+    var jsonBlueprint = pluginHelper.readConfigDefault('jsonBlueprint');
+    jsonBlueprint.script.includeContent = true;
+
+    return jsonBlueprint;
+  }
+};
+```
+
 ## What does a converted index.html file look like?
 
 The basic index.html file built by ember-cli will look soemething like this:

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ module.exports = {
           },
           script: {
             selector: 'script',
-            attributes: ['src', 'integrity']
+            attributes: ['src', 'integrity'],
+            includeContent: false,
           }
         }
       },

--- a/lib/utilities/extract-index-config.js
+++ b/lib/utilities/extract-index-config.js
@@ -1,8 +1,9 @@
 var cheerio   = require('cheerio');
 var RSVP      = require('rsvp');
 
-function _get($, selector, attributes) {
+function _get($, selector, attributes, includeContent) {
   attributes = attributes || [];
+  includeContent = includeContent || false;
   var config = [];
   var $tags = $(selector);
 
@@ -14,6 +15,11 @@ function _get($, selector, attributes) {
 
       return data;
     }, {});
+
+    var content = $tag.text().trim();
+    if (includeContent && content.length) {
+      data['content'] = content;
+    }
 
     config.push(data);
   });
@@ -29,8 +35,10 @@ module.exports = function(data) {
   for(var prop in blueprint) {
     var value = blueprint[prop];
 
-    if (value.selector && value.attributes) {
-      json[prop] = _get($, value.selector, value.attributes);
+    if ('selector' in value && ('attributes' in value || 'includeContent' in value)) {
+      var attributes = 'attributes' in value?value.attributes:[];
+      var includeContent = 'includeContent' in value?value.includeContent:false;
+      json[prop] = _get($, value.selector, value.attributes, value.includeContent);
     }
   }
 

--- a/tests/fixtures/dist/index.html
+++ b/tests/fixtures/dist/index.html
@@ -17,5 +17,6 @@
   <body>
     <script src="assets/vendor.js" integrity="sha256-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"></script>
     <script src="assets/app.js"></script>
+    <script>var a = 'foo';</script>
   </body>
 </html>

--- a/tests/unit/lib/utilities/extract-index-config-nodetest.js
+++ b/tests/unit/lib/utilities/extract-index-config-nodetest.js
@@ -11,7 +11,7 @@ describe('extract-index-config', function() {
     subject = require('../../../../lib/utilities/extract-index-config');
   });
 
-  it('extracts the correct config', function() {
+  it('extracts the correct default config', function() {
     var contents = fs.readFileSync(process.cwd() + '/tests/fixtures/dist/index.html');
 
     var plugin = {
@@ -38,6 +38,34 @@ describe('extract-index-config', function() {
         assert.deepEqual(json.base[0], { href: '/' });
         assert.deepEqual(json.script[0], { src: 'assets/vendor.js' });
         assert.deepEqual(json.script[1], { src: 'assets/app.js' });
+        assert.deepEqual(json.script[2], { });
+      });
+  });
+
+  it('extracts script contents when specified', function() {
+    var contents = fs.readFileSync(process.cwd() + '/tests/fixtures/dist/index.html');
+
+    var plugin = {
+      readConfig: function(key) {
+        return {
+          script: {
+            selector: 'script',
+            attributes: ['src'],
+            includeContent: true,
+          }
+        };
+      }
+    };
+
+    return assert.isFulfilled(subject.call(plugin, contents))
+      .then(function(config) {
+        var json = JSON.parse(config);
+
+        assert.equal(Object.keys(json).length, 1);
+
+        assert.deepEqual(json.script[0], { src: 'assets/vendor.js' });
+        assert.deepEqual(json.script[1], { src: 'assets/app.js' });
+        assert.deepEqual(json.script[2], { content: "var a = 'foo';" });
       });
   });
 });


### PR DESCRIPTION
## What Changed & Why
Added the option to `includeContents` in script tags so that inline scripts (like those required for serviceWorker) can be included.

This is essentially stolen from #22.  It does the same thing, however it doesn't change the default behavior it just adds the option.  `jsonBlueprint` has to be overridden to include the contents of a script tag so I didn't document this at this point.  The preferred solution will be to take advantage of https://github.com/ember-cli-deploy/ember-cli-deploy/issues/429 when it is closed.

I can document overriding the entire blueprint now if that is better than nothing.

## Related issues
Steals liberally from #22 and #14 which both addressed this issue, but changed the default behavior.

## PR Checklist
- [x] Add tests
- [x] Add documentation

## People
@achambers @ghedamat does this address your issues with the original PR?