### PR TITLE
Add gzip exception docs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ The following properties are expected to be present on the deployment `context` 
 
 [ember-cli-deploy-redis](https://github.com/ember-cli-deploy/ember-cli-deploy-redis)
 
+## Caveats with other plugins
+#### ember-cli-deploy-gzip
+If you're using this plugin along with [ember-cli-deploy-gzip](https://github.com/ember-cli-deploy/ember-cli-deploy-gzip) you'll need to add an exception in your gzip config in `deploy.js`:
+
+```
+gzip: {
+  ignorePattern: 'index.json'
+}
+```
+
 ## Running Tests
 
 - `npm test`


### PR DESCRIPTION
## What Changed & Why
Added a section called *Caveats with other plugins* to mention things to know when using this plugin in conjunction with other plugins. Added note about `ember-cli-deploy-gzip` mentioned in #23. Added this because I ran into it myself and found the fix in the issues for the project and a request for a PR.

## Related issues
#23 

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]

## People
@achambers @edslocombe
