### PR TITLE
Include HTML content in the JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,38 @@ ENV['json-config'] = {
 };
 ```
 
+### includeHtmlContent
+Use `includeHtmlContent` to include the contents of an HTML tag including other HTML tags.  
+
+For example if you have HTML like:
+
+```html
+<noscript>
+<p>This won't work without Javascript.</p>
+</noscript>
+
+Then 
+```javascript
+ENV['json-config'] = {
+  jsonBlueprint: {
+    noScript = {
+      selector: 'noScript',
+      includeHtmlContent: true,
+    };
+  }
+};
+```
+Would result in `JSON` of:
+
+```json
+"noScript": [
+    {
+      "htmlContent": "<p>This won't work without Javascript.</p>"
+    }
+  ],
+];
+```
+
 ## What does a converted index.html file look like?
 
 The basic index.html file built by ember-cli will look soemething like this:

--- a/lib/utilities/extract-index-config.js
+++ b/lib/utilities/extract-index-config.js
@@ -2,9 +2,10 @@
 var cheerio   = require('cheerio');
 var RSVP      = require('rsvp');
 
-function _get($, selector, attributes, includeContent) {
+function _get($, selector, attributes, includeContent, includeHtmlContent) {
   attributes = attributes || [];
   includeContent = includeContent || false;
+  includeHtmlContent = includeHtmlContent || false;
   var config = [];
   var $tags = $(selector);
 
@@ -22,6 +23,11 @@ function _get($, selector, attributes, includeContent) {
       data['content'] = content;
     }
 
+    var html = $tag.html().trim();
+    if (includeHtmlContent && html.length) {
+      data['htmlContent'] = html;
+    }
+
     config.push(data);
   });
 
@@ -37,7 +43,7 @@ module.exports = function(data) {
     var value = blueprint[prop];
 
     if ('selector' in value && ('attributes' in value || 'includeContent' in value)) {
-      json[prop] = _get($, value.selector, value.attributes, value.includeContent);
+      json[prop] = _get($, value.selector, value.attributes, value.includeContent, value.includeHtmlContent);
     }
   }
 

--- a/tests/fixtures/dist/index.html
+++ b/tests/fixtures/dist/index.html
@@ -15,6 +15,7 @@
 
   </head>
   <body>
+    <noscript>No Ember for You!</noscript>
     <script src="assets/vendor.js" integrity="sha256-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"></script>
     <script src="assets/app.js"></script>
     <script>var a = 'foo';</script>

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -135,5 +135,29 @@ describe('the deploy plugin object', function() {
           });
       });
     });
+
+    describe('when we ask for a tags html', function() {
+      before(function() {
+        jsonBlueprint = {
+          noScript: {
+            selector: 'noscript',
+            attributes: [],
+            includeHtmlContent: true,
+          }
+        };
+      });
+
+      it('provides the html contents of the tag', function() {
+        return assert.isFulfilled(promise)
+          .then(function() {
+            var contents = fs.readFileSync(fakeRoot + '/dist/index.json');
+            var json = JSON.parse(contents);
+
+            assert.equal(Object.keys(json).length, 1);
+
+            assert.deepEqual(json.noScript[0], { htmlContent: "No Ember for You!"});
+          });
+      });
+    });
   });
 });

--- a/tests/lib/utilities/extract-index-config-test.js
+++ b/tests/lib/utilities/extract-index-config-test.js
@@ -72,4 +72,29 @@ describe('extract-index-config', function() {
         assert.deepEqual(json.script[2], { content: "var a = 'foo';" });
       });
   });
+
+  it('extracts html contents when specified', function() {
+    var contents = fs.readFileSync(process.cwd() + '/tests/fixtures/dist/index.html');
+
+    var plugin = {
+      readConfig: function(/* key */) {
+        return {
+          noscriptTag: {
+            selector: 'noscript',
+            attributes: false,
+            includeHtmlContent: true
+          }
+        };
+      }
+    };
+
+    return assert.isFulfilled(subject.call(plugin, contents))
+      .then(function(config) {
+        var json = JSON.parse(config);
+
+        assert.equal(1, Object.keys(json).length);
+
+        assert.deepEqual(json.noscriptTag[0], { htmlContent: "No Ember for You!" });
+      });
+  });
 });


### PR DESCRIPTION
## What Changed & Why
Includes the tags inside of an included selector.
This might be a `<noscript>` tag or it could be an inline `<svg>`
loading indication or splash graphic.

## PR Checklist
- [x] Add tests
- [x] Add documentation
